### PR TITLE
Fix thread safety in DelayedFuncTask class

### DIFF
--- a/TTF2SDK/TTF2SDK.h
+++ b/TTF2SDK/TTF2SDK.h
@@ -80,6 +80,7 @@ private:
     std::unique_ptr<IcepickMenu> m_icepickMenu;
 
     std::list<std::shared_ptr<IFrameTask>> m_frameTasks;
+    std::recursive_mutex m_frameTasksLock;
     std::shared_ptr<DelayedFuncTask> m_delayedFuncTask;
 
     SourceInterface<IVEngineServer> m_engineServer;

--- a/TTF2SDK/TTF2SDK.h
+++ b/TTF2SDK/TTF2SDK.h
@@ -21,6 +21,8 @@ public:
     }
     virtual void RunFrame()
     {
+        std::lock_guard<std::recursive_mutex> l(m_lock);
+
         for (auto& delay : m_delayedFuncs)
         {
             delay.FramesTilRun = std::max(delay.FramesTilRun - 1, 0);
@@ -42,12 +44,12 @@ public:
 
     void AddFunc(std::function<void()> func, int frames)
     {
-        std::lock_guard<std::mutex> l(m_lock);
+        std::lock_guard<std::recursive_mutex> l(m_lock);
         m_delayedFuncs.emplace_back(frames, func);
     }
 
 private:
-    std::mutex m_lock;
+    std::recursive_mutex m_lock;
     std::list<DelayedFunc> m_delayedFuncs;
 };
 


### PR DESCRIPTION
`RunFrame()` was accessing `m_delayedFuncs` insecurely without holding a lock on mutex.

I also changed std::mutex to std::recursive_mutex, because if a delayed func called from RunFrame() calls AddFunc() again itself, it would create a deadlock with normal mutex...